### PR TITLE
Add logic to ensure stable Jsonnet dependencies on OCP4

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,9 +4,13 @@ parameters:
     cluster_kubernetes_version: "1.18"
     jsonnetfile_parameters:
       kubernetes_version: ${thanos:cluster_kubernetes_version}
+      distribution: ${facts:distribution}
       # Set this parameter if you wish to use a specific thanos-mixin
       # version.
       thanos_mixin_version: ''
+      # Set this parameter if you wish to use a specific kube-thanos
+      # version.
+      kube_thanos_version: ''
     dashboards:
       enabled: false
       namespace: ${thanos:namespace}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,20 +1,12 @@
 parameters:
   thanos:
     namespace: syn-thanos
-    # To get the hash:
-    # For each kubernetes version check the release version of kube-prometheus here:
-    # https://github.com/projectsyn/component-rancher-monitoring/blob/master/class/defaults.yml#L5
-    # Then get the hash from: https://github.com/prometheus-operator/kube-prometheus/blob/<release_version>/jsonnetfile.lock.json
-    # Where <release_version> matches the string in the map from the first link
-    thanos_mixin_version:
-      "1.18": "79d8cfdc1a00f8a96475d5d1ff1a852b184b146e"
-      "1.19": "79d8cfdc1a00f8a96475d5d1ff1a852b184b146e"
-      "1.20": "09b36547e5ed61a32a309648a8913bd02c08d3cc"
-      "1.21": "ff363498fc95cfe17de894d7237bcf38bdd0bc36"
-      "1.22": "ff363498fc95cfe17de894d7237bcf38bdd0bc36" # from: https://github.com/prometheus-operator/kube-prometheus/blob/release-0.9/jsonnetfile.lock.json#L144
     cluster_kubernetes_version: "1.18"
     jsonnetfile_parameters:
-      thanos_mixin_version: ${thanos:thanos_mixin_version:${thanos:cluster_kubernetes_version}}
+      kubernetes_version: ${thanos:cluster_kubernetes_version}
+      # Set this parameter if you wish to use a specific thanos-mixin
+      # version.
+      thanos_mixin_version: ''
     dashboards:
       enabled: false
       namespace: ${thanos:namespace}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,6 +10,47 @@ default:: `syn-thanos`
 
 The namespace in which to deploy this component.
 
+== `cluster_kubernetes_version`
+
+[horizontal]
+type:: string
+default:: `"1.18"`
+
+The Kubernetes version of the cluster on which the component is deployed.
+
+== `jsonnetfile_parameters`
+
+[horizontal]
+type:: dict
+
+Parameters for rendering the `jsonnetfile.jsonnet`.
+We pass parameter `cluster_kubernetes_version` and cluster fact `distribution` to Jsonnet to enable smart dependency version selection for the `kube-thanos` and `thanos-mixin` Jsonnet libraries.
+
+This is necessary because we need to ensure that this component and other components (for example `rancher-monitoring` and `openshift4-monitoring`) use the same `kube-thanos` and `thanos-mixin` library versions.
+
+Otherwise we get random changes in the cluster catalog at best and incompatible library versions at worst depending on which dependency version wins when `jsonnet-bundler` fetches the Jsonnet libraries.
+
+=== `jsonnetfile_parameters.thanos_mixin_version`
+
+[horizontal]
+type:: string
+default:: `''`
+
+This parameter is used as the library version for `thanos-mixin` over the autodetected version based on the cluster's Kubernetes version and distribution.
+
+Only set this parameter if you really need a specific `thanos-mixin` version for this component and have read the parameter description for `jsonnetfile_parameters` carefully.
+
+=== `jsonnetfile_parameters.kube_thanos_version`
+
+[horizontal]
+type:: string
+default:: `''`
+
+This parameter is used as the library version for `kube-thanos` over the autodetected version based on the cluster's Kubernetes version and distribution.
+
+Only set this parameter if you really need a specific `kube-thanos` version for this component and have read the parameter description for `jsonnetfile_parameters` carefully.
+
+
 == `dashboards.enabled`
 
 [horizontal]

--- a/jsonnetfile.jsonnet
+++ b/jsonnetfile.jsonnet
@@ -1,3 +1,28 @@
+// To get the hash:
+// For each kubernetes version check the release version of kube-prometheus here:
+// https://github.com/projectsyn/component-rancher-monitoring/blob/master/class/defaults.yml#L5
+// Then get the hash from: https://github.com/prometheus-operator/kube-prometheus/blob/<release_version>/jsonnetfile.lock.json
+// Where <release_version> matches the string in the map from the first link
+local thanos_mixin_version_map = {
+  '1.18': '79d8cfdc1a00f8a96475d5d1ff1a852b184b146e',
+  '1.19': '79d8cfdc1a00f8a96475d5d1ff1a852b184b146e',
+  '1.20': '09b36547e5ed61a32a309648a8913bd02c08d3cc',
+  '1.21': 'ff363498fc95cfe17de894d7237bcf38bdd0bc36',
+  '1.22': 'ff363498fc95cfe17de894d7237bcf38bdd0bc36',  // from: https://github.com/prometheus-operator/kube-prometheus/blob/release-0.9/jsonnetfile.lock.json#L144
+};
+
+local k8s_version = std.extVar('kubernetes_version');
+
+local thanos_mixin_extver = std.extVar('thanos_mixin_version');
+local thanos_mixin_version =
+  if thanos_mixin_extver != '' then
+    thanos_mixin_extver
+  else if std.objectHas(thanos_mixin_version_map, k8s_version) then
+    thanos_mixin_version_map[k8s_version]
+  else
+    // Use most recent version if we didn't find an entry in the map
+    thanos_mixin_version_map['1.22'];
+
 {
   version: 1,
   dependencies: [
@@ -17,7 +42,7 @@
           subdir: 'mixin',
         },
       },
-      version: std.extVar('thanos_mixin_version'),
+      version: thanos_mixin_version,
     },
   ],
   legacyImports: true,


### PR DESCRIPTION
* Move Jsonnet library version maps into `jsonnetfile.jsonnet`
* Add logic to select a `kube-thanos` version which matches the version used by `cluster-monitoring-operator` on OCP4 (`cluster-monitoring-operator` is pulled in via `openshift4-monitoring`)

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
