### PR TITLE
Properly configure querier stores 

### DIFF
--- a/tests/golden/defaults/thanos/thanos/query/deployment.yaml
+++ b/tests/golden/defaults/thanos/thanos/query/deployment.yaml
@@ -47,7 +47,6 @@ spec:
             - --query.replica-label=prometheus_replica
             - --query.replica-label=rule_replica
             - --store=dnssrv+_grpc._tcp.thanos-store.syn-thanos.svc.cluster.local
-            - --store=dnssrv+_grpc._tcp.thanos-store.syn-thanos.svc.cluster.local
             - --query.auto-downsampling
           env:
             - name: HOST_IP_ADDRESS


### PR DESCRIPTION
Override value provided by kube-thanos, as we're adding the store endpoint ourselves if the store component is enabled.

To achieve this, we introduce a new base layer of configuration where we set parameter `stores` to the empty array, which effectively drops any default configuration provided by kube-thanos.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Rebase before merging

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
