### PR TITLE
Add parameter to allow disabling query component

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -30,6 +30,7 @@ parameters:
               storage: 10Gi
     objectStorageConfig: {}
     query:
+      enabled: true
       replicas: 2
       serviceType: ClusterIP
       replicaLabels:

--- a/component/query.libsonnet
+++ b/component/query.libsonnet
@@ -29,7 +29,7 @@ local query = thanos.query(params.commonConfig + params.query {
   },
 };
 
-{
+if params.query.enabled then {
   ['query/' + name]: query[name]
   for name in std.objectFields(query)
-}
+} else {}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -86,6 +86,14 @@ See https://github.com/thanos-io/kube-thanos/blob/master/all.jsonnet[all.jsonnet
 
 Especially the `stores` list is important as it needs to be populated by the Thanos store API endpoints this Query should use.
 
+=== `enabled`
+
+[horizontal]
+type:: bool
+default:: `true`
+
+If the Query component should be deployed.
+
 === `serviceType`
 
 [horizontal]


### PR DESCRIPTION
In some situations we may want to only deploy a Thanos Receiver or Thanos Store, so this commit introduces a parameter to control whether the Query component is deployed.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [X] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Rebase before merging

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
