### PR TITLE
Add parameter to disable creation of namespaces

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,7 +2,7 @@ parameters:
   thanos:
     multi_instance: true
     namespace: syn-thanos
-    namespaceDisabled: false
+    createNamespace: true
     cluster_kubernetes_version: "1.18"
     jsonnetfile_parameters:
       kubernetes_version: ${thanos:cluster_kubernetes_version}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,6 +2,7 @@ parameters:
   thanos:
     multi_instance: true
     namespace: syn-thanos
+    namespaceDisabled: false
     cluster_kubernetes_version: "1.18"
     jsonnetfile_parameters:
       kubernetes_version: ${thanos:cluster_kubernetes_version}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -9,7 +9,7 @@ local configureObjStore = std.objectHas(params.objectStorageConfig, 'type');
 
 
 {
-  '00_namespace': kube.Namespace(params.namespace),
+  [if !params.namespaceDisabled then '00_namespace']: kube.Namespace(params.namespace),
   [if configureObjStore then '40_thanos_objstore']: kube.Secret(params.commonConfig.objectStorageConfig.name) {
     metadata+: {
       namespace: params.namespace,

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -9,7 +9,7 @@ local configureObjStore = std.objectHas(params.objectStorageConfig, 'type');
 
 
 {
-  [if !params.namespaceDisabled then '00_namespace']: kube.Namespace(params.namespace),
+  [if params.createNamespace then '00_namespace']: kube.Namespace(params.namespace),
   [if configureObjStore then '40_thanos_objstore']: kube.Secret(params.commonConfig.objectStorageConfig.name) {
     metadata+: {
       namespace: params.namespace,

--- a/docs/modules/ROOT/pages/how-tos/multi-instance.adoc
+++ b/docs/modules/ROOT/pages/how-tos/multi-instance.adoc
@@ -56,6 +56,7 @@ parameters:
     ...
 
   thanos_store_1:
+    createNamespace: false <3>
     commonConfig:
       objectStorageConfig:
         name: thanos-objectstorage-1 <2>
@@ -80,3 +81,4 @@ parameters:
 ----
 <1> The configuration of the common Thanos setup as required
 <2> The resource name that must be different in each instance to avoid name collisions between instances
+<3> This is required for all but one instance

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,6 +10,15 @@ default:: `syn-thanos`
 
 The namespace in which to deploy this component.
 
+== `namespaceDisabled`
+
+[horizontal]
+type:: bool
+default:: `false`
+
+If true, no namespace will be created.
+Required if the namespace is managed externally.
+
 == `cluster_kubernetes_version`
 
 [horizontal]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,14 +10,14 @@ default:: `syn-thanos`
 
 The namespace in which to deploy this component.
 
-== `namespaceDisabled`
+== `createNamespace`
 
 [horizontal]
 type:: bool
-default:: `false`
+default:: `true`
 
-If true, no namespace will be created.
-Required if the namespace is managed externally.
+If this parameter is set to `false, the component won't create the specified namespace.
+This is required for all but one instance if multiple component instances are deployed into the same namespace.
 
 == `cluster_kubernetes_version`
 

--- a/tests/golden/store/thanos/thanos/00_namespace.yaml
+++ b/tests/golden/store/thanos/thanos/00_namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations: {}
-  labels:
-    name: syn-thanos
-  name: syn-thanos

--- a/tests/store.yml
+++ b/tests/store.yml
@@ -1,5 +1,6 @@
 parameters:
   thanos:
+    namespaceDisabled: true
     commonConfig:
       objectStorageConfig:
         name: thanos-objectstorage-1

--- a/tests/store.yml
+++ b/tests/store.yml
@@ -1,6 +1,6 @@
 parameters:
   thanos:
-    namespaceDisabled: true
+    createNamespace: false
     commonConfig:
       objectStorageConfig:
         name: thanos-objectstorage-1


### PR DESCRIPTION
This PR adds an opt-out parameter to create the namespace. By default, the namespace gets created, but if using multiple instances in the same namespace, then only 1 instance shall manage the namespace.

If multiple instances are installed in the same namespace, ArgoCD "fights" between Apps over the same instance label value.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
