### PR TITLE
Add `ThanosNoStoreBlocksLoaded` alert

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -43,6 +43,7 @@ parameters:
       enabled:
         # * Enables all alerts
         "*": true
+      custom: {}
     queryRbacProxy:
       enabled: false
       ingress:
@@ -63,6 +64,21 @@ parameters:
       enabled:
         # * Enables all alerts
         "*": true
+      custom:
+        # Adapted from https://github.com/rhobs/configuration/blob/70aa0baf3d5c7a5a1a3d2e5b2828b32220944b61/resources/observability/prometheusrules/observatorium-custom-metrics-production.prometheusrules.yaml#L14
+        ThanosNoStoreBlocksLoaded:
+          enabled: false
+          rule:
+            annotations:
+              description: Thanos Store {{$labels.namespace}}/{{$labels.job}} has not loaded any blocks in the last 3 hours.
+              message: Thanos Store {{$labels.namespace}}/{{$labels.job}} has not loaded any blocks in the last 3 hours.
+              runbook_url: https://hub.syn.tools/thanos/runbooks/ThanosNoStoreBlocksLoaded.html
+              summary: Thanos Store has not loaded any blocks in the last 3 hours.
+            expr: |
+              absent(thanos_bucket_store_blocks_last_loaded_timestamp_seconds) != 1 and (time() - thanos_bucket_store_blocks_last_loaded_timestamp_seconds) > 3 * 60 * 60
+            for: 10m
+            labels:
+              severity: warning
     receive:
       enabled: false
       replicaLabels: ${thanos:query:replicaLabels}
@@ -73,6 +89,7 @@ parameters:
       enabled:
         # * Enables all alerts
         "*": true
+      custom: {}
     compactor:
       enabled: false
       replicas: 1
@@ -85,6 +102,7 @@ parameters:
       enabled:
         # * Enables all alerts
         "*": true
+      custom: {}
     images:
       thanos:
         registry: quay.io

--- a/component/compactor.libsonnet
+++ b/component/compactor.libsonnet
@@ -10,6 +10,7 @@ local params = inv.parameters.thanos;
 
 local compactor = thanos.compact(params.commonConfig + params.compactor) {
   alerts: alerts.PrometheusRuleFromMixin('thanos-compactor-alerts', [ 'thanos-compact.rules', 'thanos-compact' ], params.compactor_alerts),
+  custom_alerts: alerts.PrometheusRuleForCustom('thanos-compactor-custom-alerts', 'thanos-compactor-custom.rules', params.compactor_alerts.custom),
 };
 
 if params.compactor.enabled then {

--- a/component/query.libsonnet
+++ b/component/query.libsonnet
@@ -33,6 +33,7 @@ local query = thanos.query(queryBaseConfig + params.commonConfig + params.query 
   stores+: extraStores,
 }) {
   alerts: alerts.PrometheusRuleFromMixin('thanos-query-alerts', [ 'thanos-query', 'thanos-query.rules' ], params.query_alerts),
+  custom_alerts: alerts.PrometheusRuleForCustom('thanos-query-custom-alerts', 'thanos-query-custom.rules', params.query_alerts.custom),
 
   service+: {
     spec+: {

--- a/component/receive.libsonnet
+++ b/component/receive.libsonnet
@@ -10,6 +10,7 @@ local params = inv.parameters.thanos;
 
 local receiver = thanos.receive(params.commonConfig + params.receive) {
   alerts: alerts.PrometheusRuleFromMixin('thanos-receiver-alerts', [ 'thanos-receive', 'thanos-receive.rules' ], params.receive_alerts),
+  custom_alerts: alerts.PrometheusRuleForCustom('thanos-receive-custom-alerts', 'thanos-receive-custom.rules', params.receive_alerts.custom),
 };
 
 if params.receive.enabled then {

--- a/component/store.libsonnet
+++ b/component/store.libsonnet
@@ -10,6 +10,7 @@ local params = inv.parameters.thanos;
 
 local store = thanos.store(params.commonConfig + params.store) {
   alerts: alerts.PrometheusRuleFromMixin('thanos-store-alerts', [ 'thanos-store', 'thanos-store.rules' ], params.store_alerts),
+  custom_alerts: alerts.PrometheusRuleForCustom('thanos-store-custom-alerts', 'thanos-store-custom.rules', params.store_alerts.custom),
 
   service+: {
     spec+: {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -142,6 +142,44 @@ Available alerts can be found https://monitoring.mixins.dev/thanos/#thanos-query
 `"*": {}` allows patching all alerts.
 `AlertName: {}` patches a single alert.
 
+== `query_alerts.custom`
+
+[horizontal]
+type:: dict
+example::
++
+[source,yaml]
+----
+ThanosDidSomething:
+  enabled: false
+  rule:
+    annotations:
+      description: Thanos did something.
+      message: Thanos did something.
+      runbook: https://hub.syn.tools/thanos/runbooks/ThanosDidSomething.html
+    expr: |
+      thanos_doing_something > 1
+    for: 10m
+    labels:
+      severity: warning
+----
+
+Allows setting custom rules.
+
+=== `.custom.*.enabled`
+
+[horizontal]
+type:: boolean
+
+Controls if the custom rule is enabled.
+
+=== `.custom.*.rule`
+
+[horizontal]
+type:: dict
+
+The rule defintion.
+
 
 == `queryRbacProxy`
 
@@ -255,6 +293,44 @@ Available alerts can be found https://monitoring.mixins.dev/thanos/#thanos-store
 `"*": {}` allows patching all alerts.
 `AlertName: {}` patches a single alert.
 
+== `store_alerts.custom`
+
+[horizontal]
+type:: dict
+example::
++
+[source,yaml]
+----
+ThanosDidSomething:
+  enabled: false
+  rule:
+    annotations:
+      description: Thanos did something.
+      message: Thanos did something.
+      runbook: https://hub.syn.tools/thanos/runbooks/ThanosDidSomething.html
+    expr: |
+      thanos_doing_something > 1
+    for: 10m
+    labels:
+      severity: warning
+----
+
+Allows setting custom rules.
+
+=== `.custom.*.enabled`
+
+[horizontal]
+type:: boolean
+
+Controls if the custom rule is enabled.
+
+=== `.custom.*.rule`
+
+[horizontal]
+type:: dict
+
+The rule defintion.
+
 
 == `compactor`
 
@@ -302,6 +378,44 @@ Available alerts can be found https://monitoring.mixins.dev/thanos/#thanos-compa
 
 `"*": {}` allows patching all alerts.
 `AlertName: {}` patches a single alert.
+
+== `compactor_alerts.custom`
+
+[horizontal]
+type:: dict
+example::
++
+[source,yaml]
+----
+ThanosDidSomething:
+  enabled: false
+  rule:
+    annotations:
+      description: Thanos did something.
+      message: Thanos did something.
+      runbook: https://hub.syn.tools/thanos/runbooks/ThanosDidSomething.html
+    expr: |
+      thanos_doing_something > 1
+    for: 10m
+    labels:
+      severity: warning
+----
+
+Allows setting custom rules.
+
+=== `.custom.*.enabled`
+
+[horizontal]
+type:: boolean
+
+Controls if the custom rule is enabled.
+
+=== `.custom.*.rule`
+
+[horizontal]
+type:: dict
+
+The rule defintion.
 
 
 == `bucket`
@@ -363,6 +477,44 @@ Available alerts can be found https://monitoring.mixins.dev/thanos/#thanos-recei
 
 `"*": {}` allows patching all alerts.
 `AlertName: {}` patches a single alert.
+
+== `receive_alerts.custom`
+
+[horizontal]
+type:: dict
+example::
++
+[source,yaml]
+----
+ThanosDidSomething:
+  enabled: false
+  rule:
+    annotations:
+      description: Thanos did something.
+      message: Thanos did something.
+      runbook: https://hub.syn.tools/thanos/runbooks/ThanosDidSomething.html
+    expr: |
+      thanos_doing_something > 1
+    for: 10m
+    labels:
+      severity: warning
+----
+
+Allows setting custom rules.
+
+=== `.custom.*.enabled`
+
+[horizontal]
+type:: boolean
+
+Controls if the custom rule is enabled.
+
+=== `.custom.*.rule`
+
+[horizontal]
+type:: dict
+
+The rule defintion.
 
 
 == `images`

--- a/docs/modules/ROOT/pages/runbooks/ThanosNoStoreBlocksLoaded.adoc
+++ b/docs/modules/ROOT/pages/runbooks/ThanosNoStoreBlocksLoaded.adoc
@@ -1,0 +1,31 @@
+= Alert rule: ThanosNoStoreBlocksLoaded
+
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+During the last 3 hours, no Thanos Store block has been loaded.
+This can indicate possible data loss.
+
+== icon:bug[] Steps for debugging
+
+* Check logs, configuration for Thanos compact, store and receive components for possible cause(s).
+* Check Thanos compact Statefulset
+** Check the logs of Thanos compact pods for any errors.
+** Check for valid configuration as per <https://thanos.io/tip/components/compact.md/>
+*** Object Store configuration (--objstore.config)
+*** Downsampling configuration (--retention.resolution-*)
+*** Currently Thanos compact works as expected if the retention.resolution-raw, retention.resolution-5m and retention.resolution-1h are set for the same duration.
+** Also check guidelines for these downsampling Thanos compact command line args at: <https://thanos.io/tip/components/compact.md/>
+*** --retention.resolution-5m needs more than 40 hours
+*** --retention.resolution-1h needs to be more than 10 days
+* Check Thanos store statefulset
+** Check the logs of Thanos store pods for any errors related to blocks loading from Object store.
+** Check for valid Object store configuration (--objstore.config) as per <https://thanos.io/tip/components/store.md/>
+* Check Thanos receive Statefulset
+** Check the logs of Thanos receive pods for any errors related to blocks uploaded to Object store.
+** Check for valid Object store configuration (--objstore.config) as per <https://thanos.io/tip/components/receive.md/>
+
+== Adapted from
+
+https://github.com/rhobs/configuration/blob/70aa0baf3d5c7a5a1a3d2e5b2828b32220944b61/docs/sop/observatorium.md?plain=1#L1466

--- a/docs/modules/ROOT/pages/runbooks/_RuleTemplate.adoc
+++ b/docs/modules/ROOT/pages/runbooks/_RuleTemplate.adoc
@@ -1,0 +1,11 @@
+= Alert rule: ${rule}
+
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+// Add overview over the condition which triggers the rule
+
+== icon:bug[] Steps for debugging
+
+// Add detailed steps to debug and resolve the issue

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -3,5 +3,8 @@
 .How-to
 * xref:how-tos/multi-instance.adoc[Deploy Multiple Instances]
 
+.Alert runbooks
+* xref:runbooks/ThanosNoStoreBlocksLoaded.adoc
+
 .Technical reference
 * xref:references/parameters.adoc[Parameters]

--- a/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
+++ b/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
@@ -1,0 +1,5 @@
+[NOTE]
+====
+Please consider opening a PR to improve this runbook if you gain new information about causes of the alert, or how to debug or resolve the alert.
+Click "Edit this Page" in the top right corner to create a PR directly on GitHub.
+====

--- a/tests/all-in-one-1-18.yml
+++ b/tests/all-in-one-1-18.yml
@@ -24,6 +24,9 @@ parameters:
     store_alerts:
       enabled:
         "*": true
+      custom:
+        ThanosNoStoreBlocksLoaded:
+          enabled: true
     receive:
       enabled: true
     receive_alerts:

--- a/tests/all-in-one.yml
+++ b/tests/all-in-one.yml
@@ -18,6 +18,10 @@ parameters:
     store:
       enabled: true
       name: thanos-store-1
+    store_alerts:
+      custom:
+        ThanosNoStoreBlocksLoaded:
+          enabled: true
     receive:
       enabled: true
     compactor:

--- a/tests/golden/all-in-one-1-18/thanos/thanos/compactor/custom_alerts.yaml
+++ b/tests/golden/all-in-one-1-18/thanos/thanos/compactor/custom_alerts.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: thanos-compactor-custom-alerts
+  name: thanos-compactor-custom-alerts
+  namespace: syn-thanos
+spec:
+  groups:
+    - name: thanos-compactor-custom.rules
+      rules: []

--- a/tests/golden/all-in-one-1-18/thanos/thanos/query/custom_alerts.yaml
+++ b/tests/golden/all-in-one-1-18/thanos/thanos/query/custom_alerts.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: thanos-query-custom-alerts
+  name: thanos-query-custom-alerts
+  namespace: syn-thanos
+spec:
+  groups:
+    - name: thanos-query-custom.rules
+      rules: []

--- a/tests/golden/all-in-one-1-18/thanos/thanos/receiver/custom_alerts.yaml
+++ b/tests/golden/all-in-one-1-18/thanos/thanos/receiver/custom_alerts.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: thanos-receive-custom-alerts
+  name: thanos-receive-custom-alerts
+  namespace: syn-thanos
+spec:
+  groups:
+    - name: thanos-receive-custom.rules
+      rules: []

--- a/tests/golden/all-in-one-1-18/thanos/thanos/store/custom_alerts.yaml
+++ b/tests/golden/all-in-one-1-18/thanos/thanos/store/custom_alerts.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: thanos-store-custom-alerts
+  name: thanos-store-custom-alerts
+  namespace: syn-thanos
+spec:
+  groups:
+    - name: thanos-store-custom.rules
+      rules:
+        - alert: ThanosNoStoreBlocksLoaded
+          annotations:
+            description: Thanos Store {{$labels.namespace}}/{{$labels.job}} has not
+              loaded any blocks in the last 3 hours.
+            message: Thanos Store {{$labels.namespace}}/{{$labels.job}} has not loaded
+              any blocks in the last 3 hours.
+            runbook_url: https://hub.syn.tools/thanos/runbooks/ThanosNoStoreBlocksLoaded.html
+            summary: Thanos Store has not loaded any blocks in the last 3 hours.
+          expr: 'absent(thanos_bucket_store_blocks_last_loaded_timestamp_seconds)
+            != 1 and (time() - thanos_bucket_store_blocks_last_loaded_timestamp_seconds)
+            > 3 * 60 * 60
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: thanos

--- a/tests/golden/all-in-one/thanos/thanos/compactor/custom_alerts.yaml
+++ b/tests/golden/all-in-one/thanos/thanos/compactor/custom_alerts.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: thanos-compactor-custom-alerts
+  name: thanos-compactor-custom-alerts
+  namespace: syn-thanos
+spec:
+  groups:
+    - name: thanos-compactor-custom.rules
+      rules: []

--- a/tests/golden/all-in-one/thanos/thanos/query/custom_alerts.yaml
+++ b/tests/golden/all-in-one/thanos/thanos/query/custom_alerts.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: thanos-query-custom-alerts
+  name: thanos-query-custom-alerts
+  namespace: syn-thanos
+spec:
+  groups:
+    - name: thanos-query-custom.rules
+      rules: []

--- a/tests/golden/all-in-one/thanos/thanos/receiver/custom_alerts.yaml
+++ b/tests/golden/all-in-one/thanos/thanos/receiver/custom_alerts.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: thanos-receive-custom-alerts
+  name: thanos-receive-custom-alerts
+  namespace: syn-thanos
+spec:
+  groups:
+    - name: thanos-receive-custom.rules
+      rules: []

--- a/tests/golden/all-in-one/thanos/thanos/store/custom_alerts.yaml
+++ b/tests/golden/all-in-one/thanos/thanos/store/custom_alerts.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: thanos-store-custom-alerts
+  name: thanos-store-custom-alerts
+  namespace: syn-thanos
+spec:
+  groups:
+    - name: thanos-store-custom.rules
+      rules:
+        - alert: ThanosNoStoreBlocksLoaded
+          annotations:
+            description: Thanos Store {{$labels.namespace}}/{{$labels.job}} has not
+              loaded any blocks in the last 3 hours.
+            message: Thanos Store {{$labels.namespace}}/{{$labels.job}} has not loaded
+              any blocks in the last 3 hours.
+            runbook_url: https://hub.syn.tools/thanos/runbooks/ThanosNoStoreBlocksLoaded.html
+            summary: Thanos Store has not loaded any blocks in the last 3 hours.
+          expr: 'absent(thanos_bucket_store_blocks_last_loaded_timestamp_seconds)
+            != 1 and (time() - thanos_bucket_store_blocks_last_loaded_timestamp_seconds)
+            > 3 * 60 * 60
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: thanos

--- a/tests/golden/defaults/thanos/thanos/query/custom_alerts.yaml
+++ b/tests/golden/defaults/thanos/thanos/query/custom_alerts.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: thanos-query-custom-alerts
+  name: thanos-query-custom-alerts
+  namespace: syn-thanos
+spec:
+  groups:
+    - name: thanos-query-custom.rules
+      rules: []

--- a/tests/golden/openshift-rbac-proxy/thanos/thanos/query/custom_alerts.yaml
+++ b/tests/golden/openshift-rbac-proxy/thanos/thanos/query/custom_alerts.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: thanos-query-custom-alerts
+  name: thanos-query-custom-alerts
+  namespace: syn-thanos
+spec:
+  groups:
+    - name: thanos-query-custom.rules
+      rules: []


### PR DESCRIPTION
Adds the alert `ThanosNoStoreBlocksLoaded` adapted from [Red Hat Observability](https://github.com/rhobs) to detect if recent data is lost / not loaded.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
