### PR TITLE
Allow settings arbitrary args for the store

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -63,6 +63,7 @@ parameters:
       enabled: false
       replicas: 2
       serviceType: ClusterIP
+      additionalArgs: []
     store_alerts:
       patches: {}
       enabled:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -266,6 +266,14 @@ default:: `false`
 If the Store component should be deployed.
 It will require an `objectStorageConfig` if enabled.
 
+=== `additionalArgs`
+
+[horizontal]
+type:: array
+default:: `[]`
+
+Additional args that should be passed to the statefulset.
+
 == `store_alerts.enabled`
 
 [horizontal]


### PR DESCRIPTION
The `kube-thanos` library doesn't allow a lot of customizations for the store statefulset.

This commit adds a new config param that allows injecting arbitrary args to the store statefulset.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
