### PR TITLE
Add possibility to set extrArgs for compactor resource

### DIFF
--- a/component/compactor.libsonnet
+++ b/component/compactor.libsonnet
@@ -9,6 +9,23 @@ local inv = kap.inventory();
 local params = inv.parameters.thanos;
 
 local compactor = thanos.compact(params.commonConfig + params.compactor) {
+  statefulSet+: {
+    spec+: {
+      template+: {
+        spec+: {
+          containers: [
+            if c.name == 'thanos-compact' && 'extraArgs' in params.compactor then
+              c {
+                args+: params.compactor.extraArgs,
+              }
+            else
+              c
+            for c in super.containers
+          ],
+        },
+      },
+    },
+  },
   alerts: alerts.PrometheusRuleFromMixin('thanos-compactor-alerts', [ 'thanos-compact.rules', 'thanos-compact' ], params.compactor_alerts),
   custom_alerts: alerts.PrometheusRuleForCustom('thanos-compactor-custom-alerts', 'thanos-compactor-custom.rules', params.compactor_alerts.custom),
 };

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -361,6 +361,14 @@ default:: `false`
 If the Compactor component should be deployed.
 It will require an `objectStorageConfig` if enabled.
 
+=== `extraArgs`
+
+[horizontal]
+type:: array
+default:: `null`
+
+If the Compactor component should receive additional arguments. Those extraArgs are extending the command line arguments of the Compactor container.
+
 == `compactor_alerts.enabled`
 
 [horizontal]

--- a/tests/all-in-one.yml
+++ b/tests/all-in-one.yml
@@ -26,6 +26,13 @@ parameters:
       enabled: true
     compactor:
       enabled: true
+      extraArgs:
+        - "--wait-interval=24h"
+        - "--compact.cleanup-interval=24h"
+        - "--block-viever.global.sync-block-interval=30m"
+        - "--compact.progress-interval=0s"
+        - "--web.disable"
+        - "--consistency-delay=30m"
     compactor_alerts:
       patches:
         "*":

--- a/tests/golden/all-in-one/thanos/thanos/compactor/statefulSet.yaml
+++ b/tests/golden/all-in-one/thanos/thanos/compactor/statefulSet.yaml
@@ -59,6 +59,12 @@ spec:
             - --downsample.concurrency=1
             - --deduplication.replica-label=prometheus_replica
             - --deduplication.replica-label=rule_replica
+            - --wait-interval=24h
+            - --compact.cleanup-interval=24h
+            - --block-viever.global.sync-block-interval=30m
+            - --compact.progress-interval=0s
+            - --web.disable
+            - --consistency-delay=30m
           env:
             - name: OBJSTORE_CONFIG
               valueFrom:


### PR DESCRIPTION
I need to inject some extraArgs to compactor module, thanks to this change it's possible using tenant repo

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
